### PR TITLE
PCL  targets changed

### DIFF
--- a/Parse.Api/Parse.Api.csproj
+++ b/Parse.Api/Parse.Api.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>Parse.Api</RootNamespace>
     <AssemblyName>Parse.Api</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile88</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>


### PR DESCRIPTION
PCL supports Universal Apps now. But loses WP 7.5 and Silverlight 4
compatibility.
