### PR TITLE
Changes for Parse Server compatibility

### DIFF
--- a/Parse.Api/Constants.cs
+++ b/Parse.Api/Constants.cs
@@ -2,8 +2,6 @@
 {
     internal static class ParseUrls
     {
-        public const string BASE = "https://api.parse.com/1/";
-
         // POST to create, GET to query
         public const string CLASS = "classes/{0}";
 

--- a/Parse.Api/Models/ParseException.cs
+++ b/Parse.Api/Models/ParseException.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 
 namespace Parse.Api.Models
 {
@@ -11,5 +12,10 @@ namespace Parse.Api.Models
         public int Code { get; set; }
         public string Error { get; set; }
         public HttpStatusCode StatusCode { get; set; }
+        
+        public override String ToString()
+        {
+            return "Error " + Code + ": " + Error;
+        }
     }
 }

--- a/Parse.Api/Models/ParseObject.cs
+++ b/Parse.Api/Models/ParseObject.cs
@@ -5,6 +5,7 @@ namespace Parse.Api.Models
 {
     /// <summary>
     /// Base class for all objects in Parse
+    /// Subclasses must be named exactly as the class is named in the Parse database.
     /// </summary>
     public class ParseObject
     {


### PR DESCRIPTION
Parse.com has shut down, so this code doesn't work as is any more.  I made some very simple changes to support Parse Server instead.  Basically just replace the constant server URL with a parameter.

Sorry about all the white space changes.  Sourcetree was doing wacky things when I tried to discard that stuff, I think a line ending issue.  I can try to fix it if it's a problem.